### PR TITLE
small fixes to compile script

### DIFF
--- a/script/compile
+++ b/script/compile
@@ -7,12 +7,16 @@ if [ -z "$GRAALVM_HOME" ]; then
     exit 1
 fi
 
+if [ -z "$($GRAALVM_HOME/bin/gu list | grep native-image)" ]; then
+  echo "Please install graal's \"native-image\" with"
+  echo "\"\$GRAALVM_HOME/bin/gu\" install native-image"
+  exit 1
+fi
+
 rm -rf classes && mkdir -p classes
 clojure -M:native \
         -e '(println :direct-linking (System/getProperty "clojure.compiler.direct-linking"))' \
         -e "(compile 'grasp.native)"
-
-"$GRAALVM_HOME/bin/gu" install native-image
 
 "$GRAALVM_HOME/bin/native-image" \
     -cp "classes:$(clojure -Spath -A:native)" \

--- a/script/compile
+++ b/script/compile
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [ -z "$GRAALVM_HOME" ]; then
-    echo "Please set $GRAALVM_HOME"
+    echo "Please set \$GRAALVM_HOME"
     exit 1
 fi
 


### PR DESCRIPTION
Hello, today I was checking out `grasp` and ran into two small hiccups with the compile script. 


### escape bash variable during printing
before
```
$ ./script/compile
Please set 
```

after
```
$ ./script/compile
Please set $GRAALVM_HOME
```

### isolate `native-image` requirement because it asks for running things as `sudo` 
This change is a question of taste, so feel free to ask that I omit it.

before
```
$ ./script/compile
:direct-linking true
grasp.native
Error: Insufficient privileges for administration of the GraalVM installation. You need to become "root" user in order to perform administrative tasks on GraalVM. 
NOTE: depending on your operating system, you may need to use OS tools to install or uninstall GraalVM components.
```
This makes me want to run `sudo ./script/compile` which feels sketchy. 
Instead, one can adapt the script to check if `native-image` is installed and if not, ask that you install it. This installation should be the only thing that needs `sudo`.

so after that:
```
$ script/compile
Please install graal's "native-image" with
"$GRAALVM_HOME/bin/gu" install native-image

$ "$GRAALVM_HOME/bin/gu" install native-image
Error: Insufficient privileges for administration of the GraalVM installation. You need to become "root" user in order to perform administrative tasks on GraalVM. 
NOTE: depending on your operating system, you may need to use OS tools to install or uninstall GraalVM components.

$ sudo /usr/lib/jvm/java-8-graalvm/bin/gu install native-image
...
```