### PR TITLE
Fix error when classpath dir doesn't exist

### DIFF
--- a/src/grasp/impl.clj
+++ b/src/grasp/impl.clj
@@ -247,7 +247,7 @@
                         (sources-from-jar file))
                 (= "-" path)
                 (grasp-string (slurp *in*) spec (assoc opts :url "stdin"))
-                :else ;; assume file
+                (.exists file) ;; assume file
                 (grasp-string (slurp file) spec (assoc opts :url (.toURL file)))))))
 
 (defn resolve-symbol [sym]


### PR DESCRIPTION
Closes #22.

Also noticed the `::args+body` spec was too tight, rejecting a simple defn like
```clojure
(defn foo [] :bar)
```
