### PR TITLE
Turn valid-fn into keep-fn to allow recording more info

### DIFF
--- a/examples/arg_vecs.clj
+++ b/examples/arg_vecs.clj
@@ -20,6 +20,14 @@
 
 (def matches (grasp (System/getProperty "java.class.path") ::defn-with-large-arg-vec))
 
+(defn keep-fn [spec expr]
+  (let [conformed (s/conform spec expr)]
+    (when-not (s/invalid? conformed)
+      (with-meta expr {:conformed conformed :var-name (grasp/resolve-symbol (second expr))}))))
+
+(def matches-with-resoved-name
+  (grasp (System/getProperty "java.class.path") ::defn-with-large-arg-vec {:keep-fn keep-fn}))
+
 (defn table-row [sexpr]
   (let [conformed (s/conform ::defn sexpr)
         m (meta sexpr)

--- a/src/grasp/api.clj
+++ b/src/grasp/api.clj
@@ -6,12 +6,12 @@
 (defn grasp
   ([path-or-paths spec] (grasp path-or-paths spec nil))
   ([path-or-paths spec opts]
-   (impl/grasp path-or-paths spec (assoc opts :valid-fn s/valid?))))
+   (impl/grasp path-or-paths spec (merge {:keep-fn #(when (s/valid? %1 %2) %2)} opts))))
 
 (defn grasp-string
   ([string spec] (grasp-string string spec nil))
   ([string spec opts]
-   (impl/grasp-string string spec (assoc opts :valid-fn s/valid?))))
+   (impl/grasp-string string spec (merge {:keep-fn #(when (s/valid? %1 %2) %2)} opts))))
 
 (defn resolve-symbol [sym]
   (impl/resolve-symbol sym))

--- a/src/grasp/impl.clj
+++ b/src/grasp/impl.clj
@@ -106,14 +106,14 @@
 (defrecord Wrapper [obj])
 
 (defn match-sexprs
-  [source-tree spec valid-fn url]
+  [source-tree spec keep-fn url]
   (->> source-tree
        (tree-seq #(and ;; (do (prn (meta %)) true)
                        (seqable? %)
                        (not (string? %))
                        (not (instance? Wrapper %)))
                  clojure.core/seq)
-       (filter #(valid-fn spec %))
+       (keep #(keep-fn spec %))
        (map #(with-url url %))))
 
 (defn log-error [_ctx url reader form cause]
@@ -205,7 +205,7 @@
                                 nexpr)
                               :else nexpr))
                       nexpr)
-                    matched (match-sexprs form spec (:valid-fn opts) url)]
+                    matched (match-sexprs form spec (:keep-fn opts) url)]
                 (recur (into matches matched))))))))))
 
 (defn sources-from-jar


### PR DESCRIPTION
And show how to use it in example. Like shown in `table-row` it's fine to conform a resulting expression again but without a change like this I could not get the resolved var name because `grasp/resolve-symbol` depends on the `*ctx*` binding.