### PR TITLE
Fix typo in match access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Fix circular reference in grasp.impl
+- Fix bug in native which dropped all match results
 
 ## 0.1.4
 

--- a/src/grasp/native.clj
+++ b/src/grasp/native.clj
@@ -147,12 +147,12 @@
                            (grasp-string stdin spec opts)
                            (grasp path spec opts)))
                matches (map (fn [m] (assoc (meta m) :sexpr m)) matches)
-               batches (partition-by :url matches)]
+               batches (partition-by :uri matches)]
            (doseq [batch batches
-                   :let [url (:url (first batch))
+                   :let [uri (:uri (first batch))
                          lines (if from-stdin?
                                  (-> stdin str/split-lines)
-                                 (some-> url slurp
+                                 (some-> uri slurp
                                          str/split-lines))]
                    m batch]
              (let [{:keys [:line :end-line :column :_sexpr]} m]
@@ -161,7 +161,7 @@
                        ;;conformed (s/conform spec sexpr)
                        snippet (str/join "\n" snippet)]
                    (println (str (if from-stdin? "stdin"
-                                     url) ":"
+                                     uri) ":"
                                  line ":" column "\n" snippet))
                    ;; (prn conformed)
                    (println))))))

--- a/test/grasp/native_test.clj
+++ b/test/grasp/native_test.clj
@@ -1,0 +1,42 @@
+(ns grasp.native-test
+  (:require
+   [grasp.native :as sut]
+   [clojure.test :as t :refer [deftest is testing]]
+   [clojure.string :as str]))
+
+
+(deftest file-input-path-is-accepted
+  (testing "explicit file path"
+    (let [baos (java.io.ByteArrayOutputStream.)
+          w (java.io.OutputStreamWriter. baos)]
+      (binding [*out* w]
+        (sut/-main "src/grasp/native.clj" "-e" "#{'defn}"))
+      (let [lines (partition-all 3 (str/split-lines (str baos)))
+            lines (for [[fp found _] lines]
+                    [(last (str/split fp (re-pattern (System/getProperty "file.separator"))))
+                     found])]
+        (is (= [["native.clj:52:2" "(defn set-opts! [m]"]
+                ["native.clj:59:2" "(defn default-keep-fn"]
+                ["native.clj:64:2" "(defn grasp"]
+                ["native.clj:71:2" "(defn grasp-string"]
+                ["native.clj:78:2" "(defn rsym"]
+                ["native.clj:102:2" "(defn eval-spec [spec-string cli-path]"]
+                ["native.clj:118:2" "(defn -main [& args]"]]
+               lines)))))
+  (testing "-p flag"
+    (let [baos (java.io.ByteArrayOutputStream.)
+          w (java.io.OutputStreamWriter. baos)]
+      (binding [*out* w]
+        (sut/-main "-p" "src/grasp/native.clj" "-e" "#{'defn}"))
+      (let [lines (partition-all 3 (str/split-lines (str baos)))
+            lines (for [[fp found _] lines]
+                    [(last (str/split fp (re-pattern (System/getProperty "file.separator"))))
+                     found])]
+        (is (= [["native.clj:52:2" "(defn set-opts! [m]"]
+                ["native.clj:59:2" "(defn default-keep-fn"]
+                ["native.clj:64:2" "(defn grasp"]
+                ["native.clj:71:2" "(defn grasp-string"]
+                ["native.clj:78:2" "(defn rsym"]
+                ["native.clj:102:2" "(defn eval-spec [spec-string cli-path]"]
+                ["native.clj:118:2" "(defn -main [& args]"]]
+               lines))))))


### PR DESCRIPTION
Matches match stores the URI as :uri but the code silently drops it by accessing :url
file mode doesn't touch this code path so the bug was not surfaced.

This causes lines to be nil and nothing is printed.

Please answer the following questions and leave the below in as part of your PR.

- [X] I have read the [developer documentation](https://github.com/borkdude/grasp/blob/master/doc/dev.md).

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/borkdude/grasp/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).
  - https://github.com/borkdude/grasp/issues/32

- [X] This PR contains a [test](https://github.com/borkdude/grasp/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/borkdude/grasp/blob/master/CHANGELOG.md) file with a description of the addressed issue.
